### PR TITLE
update for nix 2.4

### DIFF
--- a/nix-universal-prefetch
+++ b/nix-universal-prefetch
@@ -26,7 +26,7 @@ EOF
 
 # Returns an object {fetcher_name: {parameter: has_default_value}}.
 def list_fetchers()
-  out, _ = Open3.capture2("nix", "eval", "--json", "(#{FETCHERS_LIST})")
+  out, _ = Open3.capture2("nix-instantiate", "--strict", "--json", "--eval", "-E", "(#{FETCHERS_LIST})")
   JSON.parse(out).to_h
 end
 
@@ -145,7 +145,7 @@ out, err, status = Open3.capture3(
 )
 
 # Here we have multiple patterns that can happen.
-PATTERNS = [
+patterns = [
   # builtins.fetchurl (nix 2.1)
   /error: hash mismatch in file downloaded from '([^']+)': got hash 'sha256:(?<hash>[[:alnum:]]+)' instead of the expected hash 'sha256:([[:alnum:]]+)'/,
   # Fixed output derivation (nix 2.1)
@@ -155,10 +155,14 @@ PATTERNS = [
   /error: hash mismatch in file downloaded from '([^']+)':\n\s+wanted:\s+([[:alnum:]]+):([[:alnum:]]+)\n\s+got:\s+(?<type>[[:alnum:]]+):(?<hash>[[:alnum:]]+)/,
   # Fixed output derivation (nix 2.2)
   /hash mismatch in fixed-output derivation '([^']+)':\n\s+wanted:\s+([[:alnum:]]+):([[:alnum:]]+)\n\s+got:\s+(?<type>[[:alnum:]]+):(?<hash>[[:alnum:]]+)/,
+  # Fixed output derivation (nix 2.4)
+  /hash mismatch in file downloaded from '([^']+)':\n\s+specified:\s+([^\s]+)\n\s+got:\s+(?<hash>[^\s]+)/,
+  # Fixed output derivation (nix 2.5pre)
+  /hash mismatch in fixed-output derivation '([^']+)':\n\s+specified:\s+([^\s]+)\n\s+got:\s+(?<hash>[^\s]+)/,
 ]
 
 # Find the first pattern matching the output
-PATTERNS.each do |patt|
+patterns.each do |patt|
   data = err.match(patt) or next
 
   # Let's print the hash.

--- a/test/nixes.nix
+++ b/test/nixes.nix
@@ -6,4 +6,5 @@ in
 {
   nix_2_3 = markhor.nix;
   nix_stable_on_unstable = unstable.nix;
+  nix_unstable_on_unstable = unstable.nixUnstable;
 }


### PR DESCRIPTION
Use the more stable nix-instantiate interface.

Here's some errors I was getting:

```
$ ./result/bin/nix-universal-prefetch --owner discourse --repo discourse --rev v2.8.0.beta8
error: '(with import <nixpkgs> { config = { allowAliases = false; }; };
         let
           # Keep only functions and functors.
           isFn = fn: lib.isFunction (normalize fn);
           # Unwraps functors' functions to look at their args.
           normalize = fn: if fn ? __functor then fn.__functor{} else fn;
           # Known fetchers
           fetchers = builtins.filter (attr: lib.hasPrefix "fetch" attr && isFn pkgs."${attr}") (lib.attrNames pkgs);
         in
         builtins.map
           # returns a list of pairs, function name, arguments.
           (f: [f (lib.functionArgs (normalize pkgs."${f}"))])
           fetchers
       )' is not a valid URL
Traceback (most recent call last):
	3: from ./result/bin/nix-universal-prefetch:33:in `<main>'
	2: from ./result/bin/nix-universal-prefetch:30:in `list_fetchers'
	1: from /nix/store/sd22ykb7najqx9bnmg1y143n18l5ssvz-ruby-2.7.4/lib/ruby/2.7.0/json/common.rb:156:in `parse'
/nix/store/sd22ykb7najqx9bnmg1y143n18l5ssvz-ruby-2.7.4/lib/ruby/2.7.0/json/common.rb:156:in `parse': 783: unexpected token at '' (JSON::ParserError)
```

```
$ ../nix-universal-prefetch/result/bin/nix-universal-prefetch --owner discourse --repo discourse --rev v2.8.0.beta8
error: cannot look up '<nixpkgs>' in pure evaluation mode (use '--impure' to override)

       at «string»:1:14:

            1| (with import <nixpkgs> { config = { allowAliases = false; }; };
             |              ^
            2|   let
Traceback (most recent call last):
	3: from ../nix-universal-prefetch/result/bin/nix-universal-prefetch:33:in `<main>'
	2: from ../nix-universal-prefetch/result/bin/nix-universal-prefetch:30:in `list_fetchers'
	1: from /nix/store/sd22ykb7najqx9bnmg1y143n18l5ssvz-ruby-2.7.4/lib/ruby/2.7.0/json/common.rb:156:in `parse'
/nix/store/sd22ykb7najqx9bnmg1y143n18l5ssvz-ruby-2.7.4/lib/ruby/2.7.0/json/common.rb:156:in `parse': 783: unexpected token at '' (JSON::ParserError)
```

New regexes are needed:

```
error: hash mismatch in file downloaded from 'file:///dev/null':
         specified: sha256:0000000000000000000000000000000000000000000000000000
         got:
         sha256:0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73
```

```
unpacking source archive /build/v2.8.0.beta8.tar.gz
error: hash mismatch in fixed-output derivation '/nix/store/x5s047gmxdgqb9ak3jl2nvmmx7frqnpi-source.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-YDPlCspb4T69ofWM74OguSqwsx4X+DGI8axmlPrbGl8=
```